### PR TITLE
added assert to ensure that all objects have at least a coadd detection

### DIFF
--- a/meds/maker.py
+++ b/meds/maker.py
@@ -19,11 +19,12 @@ except:
     have_esutil=False
 
 from .util import \
-        make_wcs_positions, \
-        get_meds_output_struct, \
-        get_meds_input_struct, \
-        get_image_info_struct, \
-        radec_to_uv
+    make_wcs_positions, \
+    get_meds_output_struct, \
+    get_meds_input_struct, \
+    get_image_info_struct, \
+    radec_to_uv, \
+    MEDSCreationError
 
 from .bounds import Bounds
 from .defaults import default_config
@@ -408,9 +409,9 @@ class MEDSMaker(dict):
             q_rc, = numpy.where(in_bnds == True)
             print('    second cut: %6d of %6d objects' % (len(q_rc),len(q)))
             
-            if file_id == 0:
-                assert len(obj_data['ra']) == len(q_rc), \
-                    'Not all objects were found in first image for MEDS making (which is the coadd/detection image by convention).'
+            if file_id == 0 and len(obj_data['ra']) != len(q_rc):
+                raise MEDSCreationError('Not all objects were found in first image for\
+ MEDS making (which is the coadd/detection image by convention).')
             
             # compose them
             q = q[q_rc]

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -410,7 +410,7 @@ class MEDSMaker(dict):
             
             if file_id == 0:
                 assert len(obj_data['ra']) == len(q_rc), \
-                    'Not all objects were found in first image for MEDS making (which is the coadd/detection image by convention).')
+                    'Not all objects were found in first image for MEDS making (which is the coadd/detection image by convention).'
             
             # compose them
             q = q[q_rc]

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -407,7 +407,11 @@ class MEDSMaker(dict):
             in_bnds = bnds.contains_points(pos['zrow'], pos['zcol'])
             q_rc, = numpy.where(in_bnds == True)
             print('    second cut: %6d of %6d objects' % (len(q_rc),len(q)))
-
+            
+            if file_id == 0:
+                assert len(obj_data['ra']) == len(q_rc), \
+                    'Not all objects were found in first image for MEDS making (which is the coadd/detection image by convention).')
+            
             # compose them
             q = q[q_rc]
 
@@ -537,7 +541,6 @@ class MEDSMaker(dict):
         with both wcs positions and zero offset positions
         """
         col,row = wcs.sky2image(ra,dec)
-
         positions = make_wcs_positions(row, col, wcs.position_offset)
         return positions
 

--- a/meds/util.py
+++ b/meds/util.py
@@ -6,6 +6,12 @@ import tempfile
 DEFVAL = -9999
 IMAGE_INFO_TYPES = ['image','weight','seg','bmask','bkg']
 
+class MEDSCreationError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
 def validate_meds(filename):
     """
     validate the input MEDS file


### PR DESCRIPTION
The idea is that if not all objects are found in the coadd/detection image, then the MEDS making has encountered a serious error and should fail. Given the convention that the MEDS file always has the coadd/detection image first, this failure makes sense to me.