### PR TITLE
added options to catch all objects for the coadd

### DIFF
--- a/meds/defaults.py
+++ b/meds/defaults.py
@@ -3,6 +3,16 @@ default_config = {
     # in arcsec
     'bounds_buffer_uv': 16.0,
 
+    # buffer for "coadd" (first entry) image in the meds in pixels
+    # objects within the coadd image bounds plus this buffer are 
+    # "in" the coadd image
+    'coadd_bounds_buffer_rowcol': 1e-3,
+    
+    # objects within 'coadd_bounds_buffer_rowcol' buffer around 
+    # the bounds of the coadd are forced to be at the edge of 
+    # the chip if 'force_into_coadd_bounds' is True    
+    'force_into_coadd_bounds': True,
+
     # allowed values in the bitmask image
     'bitmask_allowed': 0,
 


### PR DESCRIPTION
@esheldon: This PR should fix the remaining MEDS making issues. It has two features.

1. I have added the config keyword `'coadd_bounds_buffer_rowcol'`. This keyword adds (for the coadd only) a buffer in `row,col` (default: 1e-3). Anything within the coadd image boundaries (with this buffer added) is considered to be "in" the coadd image. 

2. The second config keyword I added is `'force_into_coadd_bounds'`. This keyword clips the positions of all objects determined to be "in" the coadd image (including those from 1 above) to the boundaries of the coadd image (without the buffer from 1 above). 

These two keywords combined means that an object falling outside the coadd image but in the buffer region will be marked as "in" the coadd image and then have its position moved to the edge of the image.

For our problems, this is the right thing to do. If you turn off 2 above, then you can keep objects near the edges of the coadd, but with their centers not "in" the coadd. This might be a useful feature in the future. 