### PR TITLE
PROD ignore .so in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.pyc
 build/*
+*.so


### PR DESCRIPTION
This PR ignores .so files for th efast uberseg extension.

@esheldon for viz