### PR TITLE
ENH allow variable number of jobs for joblib

### DIFF
--- a/meds/maker.py
+++ b/meds/maker.py
@@ -1342,7 +1342,7 @@ class MEDSMaker(dict):
         self._joblib_backend = self.get(
             'joblib', {}).get('backend', 'multiprocessing')
         self._joblib_max_workers = self.get(
-            'joblib', {}).get('max_joblib_workers', -1)
+            'joblib', {}).get('max_workers', -1)
         if self._joblib_backend == 'loky':
             self._joblib_threads = 1
         else:

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -339,13 +339,11 @@ class MEDSMaker(dict):
                     psf_data, file_ids, rows, cols))
 
             # run them all in parallel
-            with joblib.Parallel(
+            with joblib.parallel_backend("multiprocessing", inner_max_num_threads=1):
+                outputs = joblib.Parallel(
                     n_jobs=self._max_joblib_workers,
-                    inner_max_num_threads=1,
-                    backend='multiprocessing',
                     max_nbytes=None,
-                    verbose=50) as parallel:
-                outputs = parallel(jobs)
+                    verbose=50)(jobs)
 
             # write to disk
             # at this point all of the PSFs we need are in memory on a
@@ -928,13 +926,11 @@ class MEDSMaker(dict):
                         )
                     )
 
-            with joblib.Parallel(
+            with joblib.parallel_backend("multiprocessing", inner_max_num_threads=1):
+                outputs = joblib.Parallel(
                     n_jobs=n_jobs,
-                    inner_max_num_threads=1,
-                    backend='multiprocessing',
                     max_nbytes=None,
-                    verbose=50) as parallel:
-                outputs = parallel(jobs)
+                    verbose=50)(jobs)
 
             col = []
             row = []

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -340,7 +340,7 @@ class MEDSMaker(dict):
 
             # run them all in parallel
             with joblib.Parallel(
-                    n_jobs=-1,
+                    n_jobs=self.get('psf', {}).get('n_jobs', -1),
                     backend='multiprocessing',
                     max_nbytes=None,
                     verbose=50) as parallel:

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -422,7 +422,7 @@ class MEDSMaker(dict):
 
         print('writing psf cutouts')
 
-        if self.get('use_joblib', False):
+        if self._use_joblib:
             self._write_psf_cutouts_joblib()
         else:
             self._write_psf_cutouts_serial()
@@ -892,7 +892,7 @@ class MEDSMaker(dict):
         """
         # the cut at 250 eliminates cases where multiprocessing is
         # slower or the same due to overheads
-        if self.get('use_joblib', False) and len(ra) > 250:
+        if self._use_joblib and len(ra) > 250:
             import joblib
             n_jobs = joblib.externals.loky.cpu_count()
 
@@ -1338,6 +1338,11 @@ class MEDSMaker(dict):
         # support old way
         if 'psf_type' in self:
             self['psf'] = {'type': self['psf_type']}
+
+        if 'joblib' in self:
+            self._use_joblib = True
+        else:
+            self._use_joblib = self.get('use_joblib', False)
 
         self._joblib_backend = self.get(
             'joblib', {}).get('backend', 'multiprocessing')

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -340,7 +340,8 @@ class MEDSMaker(dict):
 
             # run them all in parallel
             with joblib.Parallel(
-                    n_jobs=self.get('psf', {}).get('n_jobs', -1),
+                    n_jobs=self.get('max_joblib_workers', -1),
+                    inner_max_num_threads=1,
                     backend='multiprocessing',
                     max_nbytes=None,
                     verbose=50) as parallel:
@@ -895,6 +896,9 @@ class MEDSMaker(dict):
             import joblib
             n_jobs = joblib.externals.loky.cpu_count()
 
+            if self.get('max_joblib_workers', -1) > 0:
+                n_jobs = min(self.get('max_joblib_workers', -1), n_jobs)
+
             n_per_job = len(ra) // n_jobs
             if n_jobs * n_per_job < len(ra):
                 n_per_job += 1
@@ -926,6 +930,7 @@ class MEDSMaker(dict):
 
             with joblib.Parallel(
                     n_jobs=n_jobs,
+                    inner_max_num_threads=1,
                     backend='multiprocessing',
                     max_nbytes=None,
                     verbose=50) as parallel:

--- a/meds/maker.py
+++ b/meds/maker.py
@@ -340,7 +340,7 @@ class MEDSMaker(dict):
 
             # run them all in parallel
             with joblib.Parallel(
-                    n_jobs=self.get('max_joblib_workers', -1),
+                    n_jobs=self._max_joblib_workers,
                     inner_max_num_threads=1,
                     backend='multiprocessing',
                     max_nbytes=None,
@@ -896,8 +896,8 @@ class MEDSMaker(dict):
             import joblib
             n_jobs = joblib.externals.loky.cpu_count()
 
-            if self.get('max_joblib_workers', -1) > 0:
-                n_jobs = min(self.get('max_joblib_workers', -1), n_jobs)
+            if self._max_joblib_workers > 0:
+                n_jobs = min(self._max_joblib_workers, n_jobs)
 
             n_per_job = len(ra) // n_jobs
             if n_jobs * n_per_job < len(ra):
@@ -1338,6 +1338,8 @@ class MEDSMaker(dict):
         # support old way
         if 'psf_type' in self:
             self['psf'] = {'type': self['psf_type']}
+
+        self._max_joblib_workers = self.get('max_joblib_workers', -1)
 
 
 def _psf_rec_func(output_path, psf_data, file_ids, rows, cols):


### PR DESCRIPTION
Adds a config key `max_joblib_workers` for controlling the number of jobs.