### PR TITLE
fix issue where wcs is sought for psf when no psf is provided.

### DIFF
--- a/meds/maker.py
+++ b/meds/maker.py
@@ -814,7 +814,7 @@ class MEDSMaker(dict):
         either load the wcs from the image_info, or from
         the image header
         """
-        if hasattr(self, 'psf_data'):
+        if self.psf_data is not None:
             psf = self.psf_data[file_id]
             if hasattr(psf, 'get_wcs'):
                 wcs = psf.get_wcs()


### PR DESCRIPTION
maker.py current fails here when no psf is provided. Fix now checks whether a psf exists first before getting wcs info for the psf image.