### PR TITLE
REF fix deprecation warning

### DIFF
--- a/meds/util.py
+++ b/meds/util.py
@@ -377,8 +377,7 @@ def thetaphi_to_unitvecs_ruv(theta,phi):
 
     rhat = numpy.array([sint*cosp,sint*sinp,cost]).T
     that = numpy.array([cost*cosp,cost*sinp,-1.0*sint]).T
-    phat = numpy.array([-1.0*sinp,cosp,numpy.zeros_like(0.0)]).T
+    phat = numpy.array([-1.0*sinp,cosp,numpy.zeros_like(sinp)]).T
 
     return rhat,phat,-1.0*that
-
 

--- a/meds/util.py
+++ b/meds/util.py
@@ -377,7 +377,7 @@ def thetaphi_to_unitvecs_ruv(theta,phi):
 
     rhat = numpy.array([sint*cosp,sint*sinp,cost]).T
     that = numpy.array([cost*cosp,cost*sinp,-1.0*sint]).T
-    phat = numpy.array([-1.0*sinp,cosp,0.0]).T
+    phat = numpy.array([-1.0*sinp,cosp,numpy.zeros_like(0.0)]).T
 
     return rhat,phat,-1.0*that
 


### PR DESCRIPTION
Numpy is now giving this deprecation warning

```
/Users/beckermr/miniconda3/envs/desy6/bin/ipython:1: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  #!/Users/beckermr/miniconda3/envs/desy6/bin/python
```

I think actually this is a long-standing bug that we have not hit yet for w/e reason.