### PR TITLE
dtype bug in _writing_cutout func

### DIFF
--- a/meds/maker.py
+++ b/meds/maker.py
@@ -258,7 +258,7 @@ class MEDSMaker(dict):
         orow_box, row_box = self._get_clipped_boxes(dims[0], orow, bsize)
         ocol_box, col_box = self._get_clipped_boxes(dims[1], ocol, bsize)
 
-        subim = zeros((bsize, bsize), dtype=im_data.dtype)
+        subim = zeros((bsize, bsize), dtype=self["%s_dtype" % cutout_type])
         subim += default_values[cutout_type]
 
         ok = (


### PR DESCRIPTION
Current code in `_write_cutout()` sets the dtype of the image array (the `subim` object) to the image cutout dtype every time even if the cutout being written is weights, noise, bmask etc. This PR has a minor, one-line update so the dtype of `subim` now matches the specific cutout type being written.